### PR TITLE
Fix for input of an element of an array of axis handles

### DIFF
--- a/legendflex/legendflex.m
+++ b/legendflex/legendflex.m
@@ -704,7 +704,7 @@ setappdata(hnew.leg, 'legflex', Lf);
 % Resize listeners
 
 addlistener(hnew.leg, 'Position', 'PostSet', @(src,evt) updatelegappdata(src,evt,hnew.leg));
-if hg2flag && strcmp(Lf.ref.Type, 'figure')
+if hg2flag && strcmp(get(Lf.ref, 'Type'), 'figure')
     addlistener(Lf.ref, 'SizeChanged', @(src,evt) updatelegpos(src,evt,hnew.leg));
 else
     addlistener(Lf.ref, 'Position', 'PostSet', @(src,evt) updatelegpos(src,evt,hnew.leg));


### PR DESCRIPTION
If I give the `ref` input of legendflex as an element of an axis handle array, the previous implementation leads to an error.
The array can be constructed by 
```matlab
axhdl = NaN(4,3);
for i = 1:11 % last element (bottom right) remains NaN
  axhdl(i) = subplot(4,3,i);
  % do plotting ...
end
lfhdl = legendflex(legdummyhdl, leglbl, 'anchor', {'se','sw'}, ...
  'ref', axhdl(4,2));
```
Maybe this only arises when the array is not completely filled with handles and some NaN remain.
This PR fixes the problem for me (Matlab R2022b).